### PR TITLE
Initial Dockerfile draft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM tensorflow/tensorflow:1.15.0-py3
+
+RUN pip install scikit-image matplotlib tifffile
+
+COPY . /app

--- a/UnMicst.py
+++ b/UnMicst.py
@@ -541,8 +541,8 @@ if __name__ == '__main__':
 	args = parser.parse_args()
 
 	logPath = ''
-	#modelPath = 'D:\\LSP\\UNet\\tonsil20x1bin1chan\\TFModel - 3class 16 kernels 5ks 2 layers'
-	modelPath = 'TFModel - 3class 16 kernels 5ks 2 layers'
+	scriptPath = os.path.dirname(os.path.realpath(__file__))
+	modelPath = os.path.join(scriptPath, 'TFModel - 3class 16 kernels 5ks 2 layers')
 	pmPath = ''
 	UNet2D.singleImageInferenceSetup(modelPath, 0)
 	imagePath = args.imagePath


### PR DESCRIPTION
1. Made modelPath to be relative to the path of the script, allowing the script to be runnable from arbitrary directory, i.e., `python /path/to/UnMicst.py /path/to/input.tif` now works from anywhere.

2. Added a Dockerfile for containerization of UnMicst.
