### PR TITLE
Fix wrapper to propagate exit code from tool script

### DIFF
--- a/unmicstWrapper.py
+++ b/unmicstWrapper.py
@@ -86,4 +86,5 @@ if args.verbose:
 
 
 print(cmd)
-os.system(cmd)
+# FIXME tool should be imported as a python module and called as a function
+os.execvp("python", cmd.split())


### PR DESCRIPTION
os.system was silently swallowing any exit code from the wrapped tool script. This change switches to os.execve which fully replaces the wrapper process with the tool script and automatically propagates the exit code. Exit code preservation is important to make Nextflow auto-retry logic workable.